### PR TITLE
fix: support statsd enhancement

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,7 +39,9 @@ func main() {
           point.Tags = append( point.Tags, &types.MetricTag{ Name: name, Value: value } )
         }
       }
-      point.Tags = append( point.Tags, &types.MetricTag{ Name: "check", Value: event.Check.Name } )
+      if event.Check != nil {
+        point.Tags = append( point.Tags, &types.MetricTag{ Name: "check", Value: event.Check.Name } )
+      }
     }
   }
 


### PR DESCRIPTION
Statsd metrics do how have an associated `event.Check` causing a invalid memory address error when enhancing statsd metrics.